### PR TITLE
モックが作成されない不具合修正

### DIFF
--- a/src/bars/__mocks__/bars.service.ts
+++ b/src/bars/__mocks__/bars.service.ts
@@ -1,5 +1,5 @@
 import { barStub } from '../test/stubs/bars.stub'
 
 export const BarsService = jest.fn().mockReturnValue({
-  findAll: jest.fn().mockResolvedValue([barStub()]),
+  find: jest.fn().mockResolvedValue([barStub()]),
 })


### PR DESCRIPTION
## 内容
- モックが作成されずテストが落ちる
→__mocks__が__mock__になっていた