### PR TITLE
bar-controllerのcreate, findByIdのテスト実装

### DIFF
--- a/src/bars/__mocks__/bars.service.ts
+++ b/src/bars/__mocks__/bars.service.ts
@@ -1,5 +1,7 @@
+import { findByIdBarStub } from '../test/stubs/bar.findById.stub'
 import { barStub } from '../test/stubs/bars.stub'
 
 export const BarsService = jest.fn().mockReturnValue({
   find: jest.fn().mockResolvedValue([barStub()]),
+  findById: jest.fn().mockResolvedValue(findByIdBarStub()),
 })

--- a/src/bars/__mocks__/bars.service.ts
+++ b/src/bars/__mocks__/bars.service.ts
@@ -2,6 +2,7 @@ import { findByIdBarStub } from '../test/stubs/bar.findById.stub'
 import { barStub } from '../test/stubs/bars.stub'
 
 export const BarsService = jest.fn().mockReturnValue({
+  create: jest.fn().mockResolvedValue(barStub()),
   find: jest.fn().mockResolvedValue([barStub()]),
   findById: jest.fn().mockResolvedValue(findByIdBarStub()),
 })

--- a/src/bars/bars.controller.ts
+++ b/src/bars/bars.controller.ts
@@ -17,7 +17,7 @@ export class BarsController {
 
   @Post()
   async create(@Body(ValidationPipe) createBarDto: CreateBarDto) {
-    this.barsService.create(createBarDto)
+    return this.barsService.create(createBarDto)
   }
 
   @Get()

--- a/src/bars/test/bars.controller.spec.ts
+++ b/src/bars/test/bars.controller.spec.ts
@@ -5,6 +5,7 @@ import { BarsService } from '../bars.service'
 import { Bar } from '../../schemas/bar.schema'
 import { barStub } from './stubs/bars.stub'
 import { findByIdBarStub } from './stubs/bar.findById.stub'
+import { CreateBarDto } from 'src/dto/create-bar.dto'
 
 jest.mock('../bars.service')
 
@@ -56,6 +57,35 @@ describe('BarsController', () => {
 
       test('then it should return specific bar', async () => {
         expect(bar).toEqual(findByIdBarStub())
+      })
+    })
+  })
+
+  describe('create', () => {
+    describe('when create is called', () => {
+      let bar: Bar
+
+      beforeEach(async () => {
+        const createBarDto: CreateBarDto = {
+          name: 'hogehoge居酒屋',
+          isPaperCigarette: false,
+          isIQos: false,
+          isVape: false,
+          PrivateRoom: '完全個室あり',
+          address: '東京都新宿区',
+          telephone: 123,
+          comments: [],
+        }
+        bar = await barsController.create(createBarDto)
+        console.log(bar)
+      })
+
+      test('then it should call barsService', () => {
+        expect(barsService.create).toHaveBeenCalled()
+      })
+
+      test('then it should return 201', () => {
+        expect(bar).toEqual(barStub()) // MEMO: mongoの_idを自動で作成して返す処理は未実装
       })
     })
   })

--- a/src/bars/test/bars.controller.spec.ts
+++ b/src/bars/test/bars.controller.spec.ts
@@ -1,10 +1,12 @@
+import * as mongoose from 'mongoose'
 import { Test } from '@nestjs/testing'
 import { BarsController } from '../bars.controller'
 import { BarsService } from '../bars.service'
 import { Bar } from '../../schemas/bar.schema'
 import { barStub } from './stubs/bars.stub'
+import { findByIdBarStub } from './stubs/bar.findById.stub'
 
-jest.mock('../bars.service') // TODO: これモック作成しているぽいけど詳しく調べる
+jest.mock('../bars.service')
 
 describe('BarsController', () => {
   let barsController: BarsController
@@ -19,7 +21,7 @@ describe('BarsController', () => {
 
     barsService = moduleRef.get<BarsService>(BarsService)
     barsController = moduleRef.get<BarsController>(BarsController)
-    jest.clearAllMocks() // TODO: これなぜclearしなければならないのか調べる
+    jest.clearAllMocks()
   })
 
   describe('findAll', () => {
@@ -31,11 +33,29 @@ describe('BarsController', () => {
       })
 
       test('then it should call barsService', () => {
-        expect(barsService.find).toHaveBeenCalled() // TODO: toHaveBeenCalledがどんなメソッドなのか調べる
+        expect(barsService.find).toHaveBeenCalled()
       })
 
       test('then it should return bars', () => {
         expect(bars).toEqual([barStub()])
+      })
+    })
+  })
+
+  describe('findById', () => {
+    describe('when findById is called', () => {
+      let bar: Bar
+
+      beforeEach(async () => {
+        bar = await barsController.findById(findByIdBarStub()._id)
+      })
+
+      test('then it should call barsService', () => {
+        expect(barsService.findById).toHaveBeenCalled()
+      })
+
+      test('then it should return specific bar', async () => {
+        expect(bar).toEqual(findByIdBarStub())
       })
     })
   })

--- a/src/bars/test/stubs/bar.findById.stub.ts
+++ b/src/bars/test/stubs/bar.findById.stub.ts
@@ -1,0 +1,31 @@
+import * as mongoose from 'mongoose'
+
+export interface BarType {
+  _id: mongoose.Types.ObjectId
+  name: string
+  isPaperCigarette: boolean
+  isIQos: boolean
+  isVape: boolean
+  PrivateRoom: string
+  address: string
+  telephone: number
+  comments: Array<mongoose.Types.ObjectId>
+  createdAt: Date
+  updatedAt: Date
+}
+
+export const findByIdBarStub = (): BarType => {
+  return {
+    _id: mongoose.Types.ObjectId('613c55f55de4fe06c9629461'),
+    name: 'hogehoge居酒屋',
+    isPaperCigarette: false,
+    isIQos: false,
+    isVape: false,
+    PrivateRoom: '完全個室あり',
+    address: '東京都新宿区',
+    telephone: 123,
+    comments: [],
+    createdAt: new Date(2021, 1, 1),
+    updatedAt: new Date(2021, 1, 1),
+  }
+}


### PR DESCRIPTION
## 実装内容
- barcontorollerのユニットテスト実装
  - create(_idは返さない)
  - findById(Stubを新たに作成してモック)